### PR TITLE
fix: client topology ownership

### DIFF
--- a/pjrt/src/api.rs
+++ b/pjrt/src/api.rs
@@ -68,7 +68,7 @@ impl Api {
         args.create_options = create_options.as_ptr();
         args.num_options = create_options.len();
         args = self.PJRT_TopologyDescription_Create(args)?;
-        Ok(TopologyDescription::wrap(self, args.topology))
+        Ok(TopologyDescription::wrap(self, args.topology, None))
     }
 
     #[allow(clippy::borrowed_box)]

--- a/pjrt/src/client.rs
+++ b/pjrt/src/client.rs
@@ -203,7 +203,7 @@ impl Client {
             .api()
             .PJRT_Client_TopologyDescription(args)
             .expect("PJRT_Client_TopologyDescription");
-        TopologyDescription::wrap(self.api(), args.topology)
+        TopologyDescription::wrap(self.api(), args.topology, Some(self))
     }
 
     // TODO:

--- a/pjrt/src/topology_description.rs
+++ b/pjrt/src/topology_description.rs
@@ -9,10 +9,11 @@ use pjrt_sys::{
     PJRT_TopologyDescription_Serialize_Args,
 };
 
-use crate::{utils, Api, DeviceDescription, NamedValue, NamedValueMap, Result};
+use crate::{utils, Api, Client, DeviceDescription, NamedValue, NamedValueMap, Result};
 
 pub struct TopologyDescription {
     pub(crate) api: Api,
+    pub(crate) client: Option<Client>,
     pub(crate) ptr: *mut PJRT_TopologyDescription,
 }
 
@@ -20,19 +21,26 @@ impl Drop for TopologyDescription {
     fn drop(&mut self) {
         let mut args = PJRT_TopologyDescription_Destroy_Args::new();
         args.topology = self.ptr;
-        self.api
-            .PJRT_TopologyDescription_Destroy(args)
-            .expect("PJRT_TopologyDescription_Destroy");
+        if self.client.is_none() {
+            self.api
+                .PJRT_TopologyDescription_Destroy(args)
+                .expect("PJRT_TopologyDescription_Destroy");
+        }
     }
 }
 
 #[bon]
 impl TopologyDescription {
-    pub(crate) fn wrap(api: &Api, ptr: *mut PJRT_TopologyDescription) -> TopologyDescription {
+    pub(crate) fn wrap(
+        api: &Api,
+        ptr: *mut PJRT_TopologyDescription,
+        client: Option<&Client>,
+    ) -> TopologyDescription {
         assert!(!ptr.is_null());
         Self {
             api: api.clone(),
             ptr,
+            client: client.cloned(),
         }
     }
 


### PR DESCRIPTION
TopologyDescription from PJRT_Client_TopologyDescription were destroy, resulting in a double free. Client TopologyDescription are owned by the client and should not be destroy.