### PR TITLE
Use c_char pointers in PJRT FFI call sites

### DIFF
--- a/pjrt/src/api.rs
+++ b/pjrt/src/api.rs
@@ -63,6 +63,8 @@
 //!     .build()?;
 //! ```
 
+use std::os::raw::c_char;
+
 use std::backtrace::Backtrace;
 use std::sync::Arc;
 
@@ -241,7 +243,7 @@ impl Api {
         let name = name.as_ref().as_bytes();
         let create_options: Vec<PJRT_NamedValue> = options.iter().map(Into::into).collect();
         let mut args = PJRT_TopologyDescription_Create_Args::new();
-        args.topology_name = name.as_ptr() as *const i8;
+        args.topology_name = name.as_ptr() as *const c_char;
         args.topology_name_size = name.len();
         args.create_options = create_options.as_ptr();
         args.num_options = create_options.len();
@@ -356,7 +358,7 @@ impl CompileToExecutable<Program> for Api {
         let mut args = PJRT_Compile_Args::new();
         args.topology = topology.ptr;
         args.program = &program.prog as *const PJRT_Program;
-        args.compile_options = options_encoded.as_ptr() as *const i8;
+        args.compile_options = options_encoded.as_ptr() as *const c_char;
         args.compile_options_size = options_encoded.len();
         if let Some(client) = client {
             args.client = client.ptr();

--- a/pjrt/src/async_transfer.rs
+++ b/pjrt/src/async_transfer.rs
@@ -173,6 +173,8 @@
 //! }
 //! ```
 
+use std::os::raw::c_char;
+
 use std::ffi::c_void;
 use std::marker::PhantomData;
 
@@ -364,7 +366,7 @@ impl AsyncHostToDeviceTransferManager {
         args.transfer_manager = self.ptr;
         args.buffer_index = buffer_index;
         args.error_code = error_code as pjrt_sys::PJRT_Error_Code;
-        args.error_message = message.as_ptr() as *const i8;
+        args.error_message = message.as_ptr() as *const c_char;
         args.error_message_size = message.len();
         self.client
             .api()

--- a/pjrt/src/buffer.rs
+++ b/pjrt/src/buffer.rs
@@ -60,6 +60,8 @@
 //! let copied_buffer = device_buffer.copy_to_device(other_device)?;
 //! ```
 
+use std::os::raw::c_char;
+
 use std::ffi::c_void;
 use std::future::Future;
 use std::pin::Pin;
@@ -462,7 +464,7 @@ impl CopyRawToHostFuture {
             args.error_code = code as pjrt_sys::PJRT_Error_Code;
         }
         if let Some(msg) = error_message {
-            args.error_message = msg.as_ptr() as *const i8;
+            args.error_message = msg.as_ptr() as *const c_char;
             args.error_message_size = msg.len();
         }
         args.dst = dst.as_mut_ptr() as *mut _;
@@ -534,7 +536,7 @@ impl DonateWithControlDependency {
             args.error_code = code as pjrt_sys::PJRT_Error_Code;
         }
         if let Some(msg) = error_message {
-            args.error_message = msg.as_ptr() as *const i8;
+            args.error_message = msg.as_ptr() as *const c_char;
             args.error_message_size = msg.len();
         }
 

--- a/pjrt/src/client.rs
+++ b/pjrt/src/client.rs
@@ -57,6 +57,8 @@
 //! println!("Compiled: {:?}", executable);
 //! ```
 
+use std::os::raw::c_char;
+
 use std::borrow::Cow;
 use std::ffi::c_void;
 use std::rc::Rc;
@@ -264,7 +266,7 @@ impl Client {
     pub fn load_executable(&self, bytes: &[u8]) -> Result<LoadedExecutable> {
         let mut args = PJRT_Executable_DeserializeAndLoad_Args::new();
         args.client = self.ptr();
-        args.serialized_executable = bytes.as_ptr() as *const i8;
+        args.serialized_executable = bytes.as_ptr() as *const c_char;
         args.serialized_executable_size = bytes.len();
         args = self.api().PJRT_Executable_DeserializeAndLoad(args)?;
         Ok(LoadedExecutable::wrap(self, args.loaded_executable))
@@ -378,7 +380,7 @@ impl Client {
         let mut args = PJRT_Client_CreateErrorBuffer_Args::new();
         args.client = self.ptr();
         args.error_code = error_code as PJRT_Error_Code;
-        args.error_message = error_message.as_ptr() as *const i8;
+        args.error_message = error_message.as_ptr() as *const c_char;
         args.error_message_size = error_message.len();
         args.shape_dims = dims.as_ptr();
         args.shape_num_dims = dims.len();
@@ -434,7 +436,7 @@ impl Client {
                 raw.state = info.state as pjrt_sys::PJRT_ProcessState;
                 raw.error_code = info.error_code.unwrap_or(0);
                 if let Some(ref msg) = info.error_message {
-                    raw.error_message = msg.as_ptr() as *const i8;
+                    raw.error_message = msg.as_ptr() as *const c_char;
                     raw.error_message_size = msg.len();
                 }
                 raw
@@ -526,7 +528,7 @@ impl CompileToLoadedExecutable<Program> for Client {
         let mut args = PJRT_Client_Compile_Args::new();
         args.client = self.ptr();
         args.program = &program.prog as *const PJRT_Program;
-        args.compile_options = options_encoded.as_ptr() as *const i8;
+        args.compile_options = options_encoded.as_ptr() as *const c_char;
         args.compile_options_size = options_encoded.len();
         args = self.api().PJRT_Client_Compile(args)?;
         Ok(LoadedExecutable::wrap(self, args.executable))
@@ -624,7 +626,7 @@ impl FulfillAliasBufferCallback {
             args.status_code = code as PJRT_Error_Code;
         }
         if let Some(msg) = error_message {
-            args.error_message = msg.as_ptr() as *const i8;
+            args.error_message = msg.as_ptr() as *const c_char;
             args.error_message_size = msg.len();
         }
         args.fulfill_alias_buffer_cb = self.ptr;

--- a/pjrt/src/device.rs
+++ b/pjrt/src/device.rs
@@ -55,6 +55,8 @@
 //! }
 //! ```
 
+use std::os::raw::c_char;
+
 use std::slice;
 
 use pjrt_sys::{
@@ -197,7 +199,7 @@ impl Device {
         let mut args = PJRT_Device_PoisonExecution_Args::new();
         args.device = self.ptr;
         args.error_code = error_code as pjrt_sys::PJRT_Error_Code;
-        args.error_message = error_message.as_ptr() as *const i8;
+        args.error_message = error_message.as_ptr() as *const c_char;
         args.error_message_size = error_message.len();
         self.client
             .api()

--- a/pjrt/src/event.rs
+++ b/pjrt/src/event.rs
@@ -11,6 +11,8 @@
 //! The `Event` struct implements Rust's `Future` trait, allowing it to be used with
 //! async/await syntax for convenient asynchronous programming.
 
+use std::os::raw::c_char;
+
 use std::ffi::c_void;
 use std::future::Future;
 use std::pin::Pin;
@@ -186,7 +188,7 @@ impl Event {
         args.event = self.ptr;
         args.error_code = error_code as PJRT_Error_Code;
         if let Some(msg) = error_message {
-            args.error_message = msg.as_ptr() as *const i8;
+            args.error_message = msg.as_ptr() as *const c_char;
             args.error_message_size = msg.len();
         }
         self.api.PJRT_Event_Set(args).map(|_| ())

--- a/pjrt/src/execute.rs
+++ b/pjrt/src/execute.rs
@@ -13,6 +13,8 @@
 //! The module provides both synchronous and asynchronous execution patterns,
 //! supporting various input types including single buffers, arrays, and vectors.
 
+use std::os::raw::c_char;
+
 use std::collections::HashSet;
 use std::ffi::{c_void, CString};
 use std::marker::PhantomData;
@@ -271,7 +273,7 @@ impl CallLocation {
     }
 
     /// Returns the raw location string as a C string pointer.
-    pub(crate) fn as_ptr(&self) -> *const i8 {
+    pub(crate) fn as_ptr(&self) -> *const c_char {
         self.location_string.as_ptr()
     }
 

--- a/pjrt/src/megascale_ext.rs
+++ b/pjrt/src/megascale_ext.rs
@@ -33,6 +33,8 @@
 //! This extension is primarily available in PJRT plugins designed for
 //! large-scale distributed training, such as TPU pods.
 
+use std::os::raw::c_char;
+
 use std::rc::Rc;
 
 use pjrt_sys::{
@@ -491,9 +493,9 @@ impl MegascaleExtension {
         args.num_slices = num_slices;
         args.local_slice_id = local_slice_id;
         args.local_host_id = local_host_id;
-        args.endpoint_addresses = endpoint_addresses.as_ptr() as *const i8;
+        args.endpoint_addresses = endpoint_addresses.as_ptr() as *const c_char;
         args.endpoint_addresses_size = endpoint_addresses.len() as i32;
-        args.dcn_topology = dcn_topology.as_ptr() as *const i8;
+        args.dcn_topology = dcn_topology.as_ptr() as *const c_char;
         args.dcn_topology_size = dcn_topology.len() as i32;
         args.client_context = client_context.ptr;
 

--- a/pjrt/src/named_value.rs
+++ b/pjrt/src/named_value.rs
@@ -15,6 +15,8 @@
 //! - `NamedValueMap`: A collection of named values backed by a HashMap
 //! - `Value`: An enum representing different value types (i64, f32, bool, string, i64 list)
 
+use std::os::raw::c_char;
+
 use std::collections::HashMap;
 use std::slice;
 
@@ -104,7 +106,7 @@ pub enum Value {
 impl<'a> From<&'a NamedValue> for PJRT_NamedValue {
     fn from(v: &'a NamedValue) -> Self {
         let mut out = PJRT_NamedValue::new();
-        out.name = v.name.as_ptr() as *const i8;
+        out.name = v.name.as_ptr() as *const c_char;
         out.name_size = v.name.len();
         match &v.value {
             Value::I64(i) => {
@@ -121,7 +123,7 @@ impl<'a> From<&'a NamedValue> for PJRT_NamedValue {
             }
             Value::String(s) => {
                 out.type_ = PJRT_NamedValue_Type_PJRT_NamedValue_kString;
-                out.__bindgen_anon_1.string_value = s.as_ptr() as *const i8;
+                out.__bindgen_anon_1.string_value = s.as_ptr() as *const c_char;
                 out.value_size = s.len();
             }
             Value::I64List(l) => {

--- a/pjrt/src/phase_compile_ext.rs
+++ b/pjrt/src/phase_compile_ext.rs
@@ -22,6 +22,8 @@
 //! let output = compiler.run_phases(&input_programs, &["phase1", "phase2"], &options, &topology)?;
 //! ```
 
+use std::os::raw::c_char;
+
 use std::rc::Rc;
 
 use pjrt_sys::{
@@ -230,9 +232,9 @@ impl PhaseCompiler {
         topology: &TopologyDescription,
     ) -> Result<PhaseCompileOutput> {
         // Convert input programs to C-compatible format
-        let input_programs_ptrs: Vec<*const i8> = input_programs
+        let input_programs_ptrs: Vec<*const c_char> = input_programs
             .iter()
-            .map(|p| p.as_ptr() as *const i8)
+            .map(|p| p.as_ptr() as *const c_char)
             .collect();
         let input_programs_sizes: Vec<usize> = input_programs.iter().map(|p| p.len()).collect();
 
@@ -244,7 +246,7 @@ impl PhaseCompiler {
                     .map_err(|_| Error::InvalidArgument("phase name contains null byte".into()))
             })
             .collect::<crate::Result<Vec<_>>>()?;
-        let phase_names_ptrs: Vec<*const i8> =
+        let phase_names_ptrs: Vec<*const c_char> =
             phase_names_cstrings.iter().map(|s| s.as_ptr()).collect();
         let phase_names_sizes: Vec<usize> = phases_to_run.iter().map(|s| s.len()).collect();
 
@@ -258,7 +260,7 @@ impl PhaseCompiler {
             input_programs: if input_programs_ptrs.is_empty() {
                 std::ptr::null_mut()
             } else {
-                input_programs_ptrs.as_ptr() as *mut *const i8
+                input_programs_ptrs.as_ptr() as *mut *const c_char
             },
             input_programs_sizes: if input_programs_sizes.is_empty() {
                 std::ptr::null()
@@ -269,7 +271,7 @@ impl PhaseCompiler {
             phases_to_run: if phase_names_ptrs.is_empty() {
                 std::ptr::null_mut()
             } else {
-                phase_names_ptrs.as_ptr() as *mut *const i8
+                phase_names_ptrs.as_ptr() as *mut *const c_char
             },
             phases_to_run_sizes: if phase_names_sizes.is_empty() {
                 std::ptr::null()
@@ -277,7 +279,7 @@ impl PhaseCompiler {
                 phase_names_sizes.as_ptr()
             },
             num_phases_to_run: phases_to_run.len(),
-            compile_options: serialized_options.as_ptr() as *const i8,
+            compile_options: serialized_options.as_ptr() as *const c_char,
             compile_options_size: serialized_options.len(),
             topology: topology.ptr,
             output_programs: std::ptr::null_mut(),

--- a/pjrt/src/program.rs
+++ b/pjrt/src/program.rs
@@ -60,6 +60,8 @@
 //! assert_eq!(format, ProgramFormat::MLIR);
 //! ```
 
+use std::os::raw::c_char;
+
 use std::fs;
 use std::path::Path;
 
@@ -132,10 +134,10 @@ impl Program {
             code: code.into(),
             prog: PJRT_Program::new(),
         };
-        program.prog.code = program.code.as_ptr() as *mut i8;
+        program.prog.code = program.code.as_ptr() as *mut c_char;
         program.prog.code_size = program.code.len();
         let format = program.format.as_bytes();
-        program.prog.format = format.as_ptr() as *const i8;
+        program.prog.format = format.as_ptr() as *const c_char;
         program.prog.format_size = format.len();
         program
     }

--- a/pjrt/src/topology_description.rs
+++ b/pjrt/src/topology_description.rs
@@ -1,3 +1,5 @@
+use std::os::raw::c_char;
+
 use std::borrow::Cow;
 use std::slice;
 
@@ -136,7 +138,7 @@ impl TopologyDescription {
     /// or after serialization for caching purposes.
     pub fn deserialize(api: &Api, bytes: &[u8]) -> Result<Self> {
         let mut args = PJRT_TopologyDescription_Deserialize_Args::new();
-        args.serialized_topology = bytes.as_ptr() as *const i8;
+        args.serialized_topology = bytes.as_ptr() as *const c_char;
         args.serialized_topology_size = bytes.len();
         let args = api.PJRT_TopologyDescription_Deserialize(args)?;
         Ok(Self::wrap(api, args.topology, None))

--- a/pjrt/src/tpu_executable_ext.rs
+++ b/pjrt/src/tpu_executable_ext.rs
@@ -27,6 +27,8 @@
 //!
 //! This extension is only available in TPU PJRT plugins.
 
+use std::os::raw::c_char;
+
 use std::rc::Rc;
 
 use pjrt_sys::{
@@ -183,7 +185,7 @@ impl TpuExecutableExtension {
     ) -> Result<OwnedTargetArguments> {
         let mut args: PJRT_TpuExecutable_GetTargetArguments_Args = unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuExecutable_GetTargetArguments_Args>();
-        args.serialized_executable = serialized_executable.as_ptr() as *const i8;
+        args.serialized_executable = serialized_executable.as_ptr() as *const c_char;
         args.serialized_executable_size = serialized_executable.len();
 
         let ext_fn = self
@@ -232,7 +234,7 @@ impl TpuExecutableExtension {
         let mut args: PJRT_TpuExecutable_GetCoreProgramAbiVersion_Args =
             unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuExecutable_GetCoreProgramAbiVersion_Args>();
-        args.serialized_executable = serialized_executable.as_ptr() as *const i8;
+        args.serialized_executable = serialized_executable.as_ptr() as *const c_char;
         args.serialized_executable_size = serialized_executable.len();
 
         let ext_fn = self
@@ -278,7 +280,7 @@ impl TpuExecutableExtension {
         let mut args: PJRT_TpuExecutable_GetHloModuleWithConfig_Args =
             unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuExecutable_GetHloModuleWithConfig_Args>();
-        args.serialized_executable = serialized_executable.as_ptr() as *const i8;
+        args.serialized_executable = serialized_executable.as_ptr() as *const c_char;
         args.serialized_executable_size = serialized_executable.len();
 
         let ext_fn = self

--- a/pjrt/src/tpu_topology_ext.rs
+++ b/pjrt/src/tpu_topology_ext.rs
@@ -31,6 +31,8 @@
 //!
 //! This extension is only available in TPU PJRT plugins.
 
+use std::os::raw::c_char;
+
 use std::borrow::Cow;
 use std::rc::Rc;
 
@@ -811,7 +813,7 @@ impl TpuTopologyExtension {
         let mut args: PJRT_TpuTopology_GetRoutingStrategy_Args = unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuTopology_GetRoutingStrategy_Args>();
         args.topology = topology.ptr;
-        args.routing_strategy = buf.as_mut_ptr() as *mut i8;
+        args.routing_strategy = buf.as_mut_ptr() as *mut c_char;
         args.routing_strategy_len = max_len;
 
         let ext_fn = self
@@ -838,9 +840,9 @@ impl TpuTopologyExtension {
         let mut slice_config: PJRT_TpuTopology_SliceConfig = unsafe { std::mem::zeroed() };
         let mut args: PJRT_TpuTopology_GetSliceConfig_Args = unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuTopology_GetSliceConfig_Args>();
-        args.platform_type_name = platform_type_name.as_ptr() as *const i8;
+        args.platform_type_name = platform_type_name.as_ptr() as *const c_char;
         args.platform_type_name_len = platform_type_name.len();
-        args.slice_name = slice_name.as_ptr() as *const i8;
+        args.slice_name = slice_name.as_ptr() as *const c_char;
         args.slice_name_len = slice_name.len();
         args.slice_config = &mut slice_config;
 
@@ -868,7 +870,7 @@ impl TpuTopologyExtension {
             vec![unsafe { std::mem::zeroed() }; max_configs];
         let mut args: PJRT_TpuTopology_GetSliceConfigs_Args = unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuTopology_GetSliceConfigs_Args>();
-        args.platform_type_name = platform_type_name.as_ptr() as *const i8;
+        args.platform_type_name = platform_type_name.as_ptr() as *const c_char;
         args.platform_type_name_len = platform_type_name.len();
         args.slice_configs = buf.as_mut_ptr();
         args.max_slice_configs = max_configs;
@@ -895,7 +897,7 @@ impl TpuTopologyExtension {
         let mut args: PJRT_TpuTopology_GetDefaultPlatformConfig_Args =
             unsafe { std::mem::zeroed() };
         args.struct_size = std::mem::size_of::<PJRT_TpuTopology_GetDefaultPlatformConfig_Args>();
-        args.platform_type_name = platform_type_name.as_ptr() as *const i8;
+        args.platform_type_name = platform_type_name.as_ptr() as *const c_char;
         args.platform_type_name_len = platform_type_name.len();
 
         let ext_fn = self

--- a/pjrt/src/triton_ext.rs
+++ b/pjrt/src/triton_ext.rs
@@ -25,6 +25,8 @@
 //! println!("Shared memory: {} bytes", result.smem_bytes);
 //! ```
 
+use std::os::raw::c_char;
+
 use std::rc::Rc;
 
 use pjrt_sys::{PJRT_Triton, PJRT_Triton_Compile_Args};
@@ -113,9 +115,9 @@ impl TritonExtension {
     ) -> Result<TritonCompileResult> {
         let mut args = unsafe { std::mem::zeroed::<PJRT_Triton_Compile_Args>() };
         args.struct_size = std::mem::size_of::<PJRT_Triton_Compile_Args>();
-        args.module = module.as_ptr() as *const i8;
+        args.module = module.as_ptr() as *const c_char;
         args.module_size = module.len();
-        args.arch_name = arch_name.as_ptr() as *const i8;
+        args.arch_name = arch_name.as_ptr() as *const c_char;
         args.arch_name_size = arch_name.len();
         args.num_warps = num_warps;
         args.num_ctas = num_ctas;


### PR DESCRIPTION
Fixes #3.

On targets where `c_char` is `u8` (e.g. `aarch64-unknown-linux-gnu`), `cargo build -p pjrt` fails with many `E0308` mismatches (`*const/*mut i8` vs `*const/*mut u8`) in PJRT FFI call paths.

This change replaces hardcoded `i8` pointer types/casts with `std::os::raw::c_char` in the wrapper (`pjrt/src/*`), including phase-compile pointer vectors.

No behavior change; this is a type-correctness fix at the C FFI boundary.